### PR TITLE
1409 プライベートメッセージがすべて読めない

### DIFF
--- a/message-editor-util.php
+++ b/message-editor-util.php
@@ -52,5 +52,28 @@ class message_editor_util {
 
         return false;
     }
-}
 
+    public static function qa_db_recent_messages_selectspec($fromidentifier, $fromisuserid, $toidentifier, $toisuserid)
+    {
+        if (isset($fromidentifier)) {
+            $fromsub = $fromisuserid ? '$' : '(SELECT userid FROM ^users WHERE handle=$ LIMIT 1)';
+            $where = 'fromuserid=' . $fromsub . " AND type='PRIVATE'";
+        }
+        else
+            $where = "type='PUBLIC'";
+        $tosub = $toisuserid ? '$' : '(SELECT userid FROM ^users WHERE handle=$ LIMIT 1)';
+
+        $source = '^messages LEFT JOIN ^users ufrom ON fromuserid=ufrom.userid LEFT JOIN ^users uto ON touserid=uto.userid WHERE ' . $where . ' AND touserid=' . $tosub . ' ORDER BY ^messages.created DESC';
+
+        $arguments = isset($fromidentifier) ? array($fromidentifier, $toidentifier) : array($toidentifier);
+
+        return array(
+            'columns' => qa_db_messages_columns(),
+            'source' => $source,
+            'arguments' => $arguments,
+            'arraykey' => 'messageid',
+            'sortdesc' => 'created',
+        );
+    }
+
+}

--- a/message.php
+++ b/message.php
@@ -41,8 +41,8 @@
 
     list($toaccount, $torecent, $fromrecent) = qa_db_select_with_pending(
         qa_db_user_account_selectspec($handle, false),
-        qa_db_recent_messages_selectspec($loginuserid, true, $handle, false),
-        qa_db_recent_messages_selectspec($handle, false, $loginuserid, true)
+        message_editor_util::qa_db_recent_messages_selectspec($loginuserid, true, $handle, false),
+        message_editor_util::qa_db_recent_messages_selectspec($handle, false, $loginuserid, true)
     );
 
 
@@ -141,7 +141,7 @@
 
 
     $start = qa_get_start();
-    $pagesize = QA_DB_RETRIEVE_MESSAGES;
+    $pagesize = qa_opt('page_size_pms');
     
     // $hideForm = !empty($pageerror) || $messagesent;
     $hideForm = !empty($pageerror);
@@ -204,7 +204,7 @@
 
         qa_sort_by($recent, 'created');
 
-        $showmessages = array_slice(array_reverse($recent, true), $start, QA_DB_RETRIEVE_MESSAGES);
+        $showmessages = array_slice(array_reverse($recent, true), $start, $pagesize);
 
         if (count($showmessages)) {
             $handle = $toaccount['handle'];


### PR DESCRIPTION
- メッセージ取得時すべて読み込む
- 表示件数は固定でなく管理センターオプションで指定できるようにする