### PR TITLE
1439 プライベートメッセージ上部に説明を表示する

### DIFF
--- a/message-editor-util.php
+++ b/message-editor-util.php
@@ -76,4 +76,18 @@ class message_editor_util {
         );
     }
 
+    public static function is_message_posted($fromuserid, $touserid)
+    {
+        $sql = "";
+        $sql = "SELECT COUNT(*)";
+        $sql.= " FROM ^messages";
+        $sql.= " WHERE type = 'PRIVATE'";
+        $sql.= " AND fromuserid = $";
+        $sql.= " AND touserid = $";
+
+        $count = qa_db_read_one_value(qa_db_query_sub($sql, $fromuserid, $touserid));
+
+        return ($count > 0);
+    }
+
 }

--- a/message.php
+++ b/message.php
@@ -226,7 +226,11 @@
 
 
     $qa_content['raw']['account'] = $toaccount; // for plugin layers to access
-
+    if (!message_editor_util::is_message_posted($loginuserid, $toaccount['userid'])) {
+        $qa_content['no_post_html'] = qa_opt('message_editor_no_post_html');
+    } else {
+        $qa_content['no_post_html'] = '';
+    }
     return $qa_content;
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,12 @@
+{
+	"name": "Message Editor",
+	"uri": "",
+	"description": "Change message page editor to Medium",
+	"version": "1.0",
+	"date": "2017-01-06",
+	"author": "yshiga",
+	"author_uri": "http://38qa.net",
+	"license": "GPLv2",
+	"update_uri": "",
+	"min_q2a": "1.7"
+}

--- a/qa-message-editor-admin.php
+++ b/qa-message-editor-admin.php
@@ -1,0 +1,54 @@
+<?php
+
+class qa_message_editor_admin
+{
+    public function init_queries($tableslc)
+    {
+        return;
+    }
+    
+    public function option_default($option)
+    {
+        switch ($option) {
+            default:
+                return;
+        }
+    }
+
+    public function allow_template($template)
+    {
+        return $template !== 'admin';
+    }
+
+    public function admin_form(&$qa_content)
+    {
+        // process the admin form if admin hit Save-Changes-button
+        $ok = null;
+        if (qa_clicked('qa_message_editor_save')) {
+            qa_opt('message_editor_no_post_html', qa_post_text('message_editor_no_post_html'));
+            $ok = qa_lang('admin/options_saved');
+        }
+
+        // form fields to display frontend for admin
+        $fields = array();
+
+        $fields[] = array(
+            'label' => qa_lang('message_editor/no_post_html'),
+            'tags' => 'NAME="message_editor_no_post_html"',
+            'value' => qa_opt('message_editor_no_post_html'),
+            'type' => 'textarea',
+            'rows' => 5,
+        );
+
+        return array(
+            'ok' => ($ok && !isset($error)) ? $ok : null,
+            'fields' => $fields,
+            'buttons' => array(
+                array(
+                    'label' => qa_lang_html('main/save_button'),
+                    'tags' => 'name="qa_message_editor_save"',
+                ),
+            ),
+        );
+    }
+}

--- a/qa-message-editor-lang-default.php
+++ b/qa-message-editor-lang-default.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+    'no_post_html'      => 'メッセージ未投稿時の案内(HTML可)',
+);
+
+/*
+    Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -24,5 +24,9 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 @define( 'MESSAGE_EDITOR_RELATIVE_PATH', '../qa-plugin/'.MESSAGE_EDITOR_FOLDER.'/');
 @define( 'MEDIUM_EDITOR_DIR', '../qa-plugin/q2a-medium-editor/');
 
+// language file
+qa_register_plugin_phrases('qa-message-editor-lang-*.php', 'message_editor');
+// admin
+qa_register_plugin_module('module', 'qa-message-editor-admin.php', 'qa_message_editor_admin', 'Message Editor');
 // override
 qa_register_plugin_overrides('qa-message-editor-overrides.php');


### PR DESCRIPTION
- メッセージ未送信の場合のHTMLを管理画面オプションに追加
- メッセージ未送信の場合にHTMLを取得して`$qa_content`にいれておく